### PR TITLE
Using counters to dynamically set tokenId in mint

### DIFF
--- a/src/ERC4973.sol
+++ b/src/ERC4973.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.6;
 
 import {ERC165} from "./ERC165.sol";
+import {Counters} from "@openzeppelin/contracts/utils/Counters.sol";
 
 import {IERC721Metadata} from "./interfaces/IERC721Metadata.sol";
 import {IERC4973} from "./interfaces/IERC4973.sol";
@@ -12,6 +13,9 @@ import {IERC4973} from "./interfaces/IERC4973.sol";
 abstract contract ERC4973 is ERC165, IERC721Metadata, IERC4973 {
   string private _name;
   string private _symbol;
+
+  using Counters for Counters.Counter;
+  Counters.Counter private _tokenIds;
 
   mapping(uint256 => address) private _owners;
   mapping(uint256 => string) private _tokenURIs;
@@ -68,14 +72,18 @@ abstract contract ERC4973 is ERC165, IERC721Metadata, IERC4973 {
 
   function _mint(
     address to,
-    uint256 tokenId,
     string memory uri
   ) internal virtual returns (uint256) {
-    require(!_exists(tokenId), "mint: tokenID exists");
+    uint256 tokenId = _tokenIds.current();
+
     _balances[to] += 1;
     _owners[tokenId] = to;
     _tokenURIs[tokenId] = uri;
+    
     emit Attest(to, tokenId);
+    
+    _tokenIds.increment();
+    
     return tokenId;
   }
 

--- a/src/ERC4973.t.sol
+++ b/src/ERC4973.t.sol
@@ -13,10 +13,9 @@ contract AccountBoundToken is ERC4973 {
 
   function mint(
     address to,
-    uint256 tokenId,
     string calldata uri
   ) external returns (uint256) {
-    return super._mint(to, tokenId, uri);
+    return super._mint(to, uri);
   }
 }
 
@@ -69,8 +68,7 @@ contract ERC4973Test is Test {
     address to = msg.sender;
     assertEq(abt.balanceOf(to), 0);
     string memory tokenURI = "https://example.com/metadata.json";
-    uint256 tokenId = 0;
-    abt.mint(to, tokenId, tokenURI);
+    abt.mint(to, tokenURI);
     assertEq(abt.balanceOf(to), 1);
   }
 
@@ -78,8 +76,7 @@ contract ERC4973Test is Test {
     address to = address(this);
     assertEq(abt.balanceOf(to), 0);
     string memory tokenURI = "https://example.com/metadata.json";
-    uint256 tokenId = 0;
-    abt.mint(to, tokenId, tokenURI);
+    uint256 tokenId = abt.mint(to, tokenURI);
     assertEq(abt.balanceOf(to), 1);
     abt.burn(tokenId);
     assertEq(abt.balanceOf(to), 0);
@@ -87,8 +84,7 @@ contract ERC4973Test is Test {
 
   function testMint() public {
     string memory tokenURI = "https://example.com/metadata.json";
-    uint256 tokenId = 0;
-    abt.mint(msg.sender, tokenId, tokenURI);
+    uint256 tokenId = abt.mint(msg.sender, tokenURI);
     assertEq(abt.tokenURI(tokenId), tokenURI);
     assertEq(abt.ownerOf(tokenId), msg.sender);
   }
@@ -96,17 +92,15 @@ contract ERC4973Test is Test {
   function testMintToExternalAddress() public {
     address thirdparty = address(1337);
     string memory tokenURI = "https://example.com/metadata.json";
-    uint256 tokenId = 0;
-    abt.mint(thirdparty, tokenId, tokenURI);
+    uint256 tokenId = abt.mint(thirdparty, tokenURI);
     assertEq(abt.tokenURI(tokenId), tokenURI);
     assertEq(abt.ownerOf(tokenId), thirdparty);
   }
 
   function testMintAndBurn() public {
     string memory tokenURI = "https://example.com/metadata.json";
-    uint256 tokenId = 0;
     address to = address(this);
-    abt.mint(to, tokenId, tokenURI);
+    uint256 tokenId = abt.mint(to, tokenURI);
     assertEq(abt.ownerOf(tokenId), to);
     assertEq(abt.tokenURI(tokenId), tokenURI);
     abt.burn(tokenId);
@@ -114,9 +108,8 @@ contract ERC4973Test is Test {
 
   function testBurnAsNonAuthorizedAccount() public {
     string memory tokenURI = "https://example.com/metadata.json";
-    uint256 tokenId = 0;
     address to = address(this);
-    abt.mint(to, tokenId, tokenURI);
+    uint256 tokenId = abt.mint(to, tokenURI);
     assertEq(abt.ownerOf(tokenId), to);
     assertEq(abt.tokenURI(tokenId), tokenURI);
 
@@ -128,9 +121,8 @@ contract ERC4973Test is Test {
 
   function testBurnNonExistentTokenId() public {
     string memory tokenURI = "https://example.com/metadata.json";
-    uint256 tokenId = 0;
     address to = address(this);
-    abt.mint(to, tokenId, tokenURI);
+    uint256 tokenId = abt.mint(to, tokenURI);
     assertEq(abt.ownerOf(tokenId), to);
     assertEq(abt.tokenURI(tokenId), tokenURI);
 
@@ -138,15 +130,6 @@ contract ERC4973Test is Test {
     vm.expectRevert(bytes("ownerOf: token doesn't exist"));
 
     nac.burn(address(abt), 1337);
-  }
-
-  function testFailToMintTokenToPreexistingTokenId() public {
-    string memory tokenURI = "https://example.com/metadata.json";
-    uint256 tokenId = 0;
-    abt.mint(msg.sender, tokenId, tokenURI);
-    assertEq(abt.tokenURI(tokenId), tokenURI);
-    assertEq(abt.ownerOf(tokenId), msg.sender);
-    abt.mint(msg.sender, tokenId, tokenURI);
   }
 
   function testFailRequestingNonExistentTokenURI() public view {

--- a/src/ERC4973Permit.sol
+++ b/src/ERC4973Permit.sol
@@ -29,7 +29,6 @@ abstract contract ERC4973Permit is ERC4973, EIP712, IERC4973Permit {
 
   function mintWithPermission(
     address from,
-    uint256 tokenId,
     string calldata uri,
     uint8 v,
     bytes32 r,
@@ -40,7 +39,7 @@ abstract contract ERC4973Permit is ERC4973, EIP712, IERC4973Permit {
       "mintWithPermission: invalid permission"
     );
 
-    return _mint(msg.sender, tokenId, uri);
+    return _mint(msg.sender, uri);
   }
 
   function getMintPermitMessageHash(

--- a/src/ERC4973Permit.t.sol
+++ b/src/ERC4973Permit.t.sol
@@ -23,12 +23,11 @@ contract ERC4973Test is Test {
 
   function testIERC4973Permit() public {
     bytes4 interfaceId = type(IERC4973Permit).interfaceId;
-    assertEq(interfaceId, bytes4(0x85d685d2));
+    assertEq(interfaceId, bytes4(0x6b65efaa));
     assertTrue(abt.supportsInterface(interfaceId));
   }
 
   function testMintWithDifferentTokenURI() public {
-    uint256 tokenId = 0;
     string memory tokenURI = "https://contenthash.com";
     address to = address(this);
 
@@ -38,18 +37,17 @@ contract ERC4973Test is Test {
     address unauthorizedFrom = address(1337);
 
     vm.expectRevert(bytes("mintWithPermission: invalid permission"));
-    abt.mintWithPermission(
+    uint256 tokenId = abt.mintWithPermission(
       unauthorizedFrom,
-      tokenId,
       tokenURI,
       v,
       r,
       s
     );
+    assertEq(0, tokenId);
   }
 
   function testMintWithUnauthorizedSender() public {
-    uint256 tokenId = 0;
     string memory tokenURI = "https://contenthash.com";
     address to = address(this);
 
@@ -58,27 +56,25 @@ contract ERC4973Test is Test {
     address unauthorizedFrom = address(1337);
 
     vm.expectRevert(bytes("mintWithPermission: invalid permission"));
-    abt.mintWithPermission(
+    uint256 tokenId = abt.mintWithPermission(
       unauthorizedFrom,
-      tokenId,
       tokenURI,
       v,
       r,
       s
     );
+    assertEq(0, tokenId);
   }
 
   function testMintWithPermit() public {
-    uint256 tokenId = 0;
     string memory tokenURI = "https://contenthash.com";
     address to = address(this);
 
     bytes32 hash = abt.getMintPermitMessageHash(fromAddress, to, tokenURI);
     (uint8 v, bytes32 r, bytes32 s) = vm.sign(fromPrivateKey, hash);
 
-    abt.mintWithPermission(
+    uint256 tokenId = abt.mintWithPermission(
       fromAddress,
-      tokenId,
       tokenURI,
       v,
       r,

--- a/src/interfaces/IERC4973Permit.sol
+++ b/src/interfaces/IERC4973Permit.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.6;
 
 /// @title Account-bound tokens, optional permissioned minting extension
 /// @dev See https://eips.ethereum.org/EIPS/eip-4973
-/// Note: the ERC-165 identifier for this interface is 0x85d685d2
+/// Note: the ERC-165 identifier for this interface is 0x6b65efaa
 interface IERC4973Permit {
-  function mintWithPermission(address from, uint256 tokenId, string calldata uri, uint8 v, bytes32 r, bytes32 s) external returns (uint256);
+  function mintWithPermission(address from, string calldata uri, uint8 v, bytes32 r, bytes32 s) external returns (uint256);
 }


### PR DESCRIPTION
Fixes https://github.com/rugpullindex/ERC4973/issues/19

Will reflect the new interface ID in EIP after PR is merged. 