### PR TITLE
fix: bump minimum Solidity version for ERC4973.sol to 0.8.8

### DIFF
--- a/src/ERC4973.sol
+++ b/src/ERC4973.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.6;
+pragma solidity ^0.8.8;
 
 import {ERC165} from "./ERC165.sol";
 


### PR DESCRIPTION
Fixed #29 