### PR TITLE
Patch: packing tokenURI as keccak256

### DIFF
--- a/src/ERC4973Permit.sol
+++ b/src/ERC4973Permit.sol
@@ -64,7 +64,12 @@ abstract contract ERC4973Permit is ERC4973, EIP712, IERC4973Permit {
     string calldata tokenURI
   ) internal view returns (bytes32) {
     bytes32 structHash = keccak256(
-      abi.encode(MINT_PERMIT_TYPEHASH, from, to, tokenURI)
+      abi.encode(
+        MINT_PERMIT_TYPEHASH,
+        from,
+        to,
+        keccak256(bytes(tokenURI))
+      )
     );
     return _hashTypedDataV4(structHash);
   }


### PR DESCRIPTION
While performing end-to-end integration testing with otterspace, I found that string params need to be packed with keccak256, without which the hashes generated off-chain (via ethers.js) do not match with hashes generate on-chain.

