### PR TITLE
Adding `from` to Transfer event

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.0
+
+- Signature change `_mint(address from, address to, uin256 tokenId, string memory uri)`
+- Transfer event now emits the passed in `from` address rather than hardcoding it to `address(0)`
+
 ## 0.3.0
 
 - Comply with standard specification at: https://github.com/ethereum/EIPs/tree/96a91604a547781a596de6af4cb22ec60c4601db

--- a/src/ERC4973.sol
+++ b/src/ERC4973.sol
@@ -82,7 +82,7 @@ abstract contract ERC4973 is EIP712, ERC165, IERC721Metadata, IERC4973 {
   ) external virtual returns (uint256) {
     require(msg.sender != to, "give: cannot give from self");
     uint256 tokenId = _safeCheckAgreement(msg.sender, to, uri, signature);
-    _mint(to, tokenId, uri);
+    _mint(msg.sender, to, tokenId, uri);
     _usedHashes.set(tokenId);
     return tokenId;
   }
@@ -94,7 +94,7 @@ abstract contract ERC4973 is EIP712, ERC165, IERC721Metadata, IERC4973 {
   ) external virtual returns (uint256) {
     require(msg.sender != from, "take: cannot take from self");
     uint256 tokenId = _safeCheckAgreement(msg.sender, from, uri, signature);
-    _mint(msg.sender, tokenId, uri);
+    _mint(from, msg.sender, tokenId, uri);
     _usedHashes.set(tokenId);
     return tokenId;
   }
@@ -137,6 +137,7 @@ abstract contract ERC4973 is EIP712, ERC165, IERC721Metadata, IERC4973 {
   }
 
   function _mint(
+    address from,
     address to,
     uint256 tokenId,
     string memory uri
@@ -145,7 +146,7 @@ abstract contract ERC4973 is EIP712, ERC165, IERC721Metadata, IERC4973 {
     _balances[to] += 1;
     _owners[tokenId] = to;
     _tokenURIs[tokenId] = uri;
-    emit Transfer(address(0), to, tokenId);
+    emit Transfer(from, to, tokenId);
     return tokenId;
   }
 

--- a/src/ERC4973.t.sol
+++ b/src/ERC4973.t.sol
@@ -90,6 +90,12 @@ contract ERC4973Test is Test {
   address passiveAddress = 0x0f6A79A579658E401E0B81c6dde1F2cd51d97176;
   uint256 passivePrivateKey = 0xad54bdeade5537fb0a553190159783e45d02d316a992db05cbed606d3ca36b39;
 
+  event Transfer(
+    address indexed from,
+    address indexed to,
+    uint256 indexed tokenId
+  );
+
   function setUp() public {
     abt = new AccountBoundToken();
     approver = new ERC1271Mock(true);
@@ -131,7 +137,11 @@ contract ERC4973Test is Test {
     assertEq(abt.balanceOf(to), 0);
     string memory tokenURI = "https://example.com/metadata.json";
     uint256 tokenId = 0;
+
+    vm.expectEmit(true, true, true, false);
+    emit Transfer(from, to, tokenId);
     abt.mint(from, to, tokenId, tokenURI);
+
     assertEq(abt.balanceOf(to), 1);
   }
 
@@ -141,7 +151,11 @@ contract ERC4973Test is Test {
     assertEq(abt.balanceOf(to), 0);
     string memory tokenURI = "https://example.com/metadata.json";
     uint256 tokenId = 0;
+
+    vm.expectEmit(true, true, true, false);
+    emit Transfer(from, to, tokenId);
     abt.mint(from, to, tokenId, tokenURI);
+
     assertEq(abt.balanceOf(to), 1);
     abt.unequip(tokenId);
     assertEq(abt.balanceOf(to), 0);
@@ -151,7 +165,11 @@ contract ERC4973Test is Test {
     address from = address(0);
     string memory tokenURI = "https://example.com/metadata.json";
     uint256 tokenId = 0;
+
+    vm.expectEmit(true, true, true, false);
+    emit Transfer(from, msg.sender, tokenId);
     abt.mint(from, msg.sender, tokenId, tokenURI);
+
     assertEq(abt.tokenURI(tokenId), tokenURI);
     assertEq(abt.ownerOf(tokenId), msg.sender);
   }
@@ -161,7 +179,11 @@ contract ERC4973Test is Test {
     address thirdparty = address(1337);
     string memory tokenURI = "https://example.com/metadata.json";
     uint256 tokenId = 0;
+
+    vm.expectEmit(true, true, true, false);
+    emit Transfer(from, thirdparty, tokenId);
     abt.mint(from, thirdparty, tokenId, tokenURI);
+
     assertEq(abt.tokenURI(tokenId), tokenURI);
     assertEq(abt.ownerOf(tokenId), thirdparty);
   }
@@ -171,7 +193,11 @@ contract ERC4973Test is Test {
     address from = address(0);
     address to = address(this);
     uint256 tokenId = 0;
+
+    vm.expectEmit(true, true, true, false);
+    emit Transfer(from, to, tokenId);
     abt.mint(from, to, tokenId, tokenURI);
+
     assertEq(abt.ownerOf(tokenId), to);
     assertEq(abt.tokenURI(tokenId), tokenURI);
     abt.unequip(tokenId);
@@ -182,7 +208,11 @@ contract ERC4973Test is Test {
     address from = address(0);
     address to = address(this);
     uint256 tokenId = 0;
+
+    vm.expectEmit(true, true, true, false);
+    emit Transfer(from, to, tokenId);
     abt.mint(from, to, tokenId, tokenURI);
+
     assertEq(abt.ownerOf(tokenId), to);
     assertEq(abt.tokenURI(tokenId), tokenURI);
 
@@ -197,7 +227,11 @@ contract ERC4973Test is Test {
     address to = address(this);
     address from = address(0);
 		uint256 tokenId = 0;
+
+    vm.expectEmit(true, true, true, false);
+    emit Transfer(from, to, tokenId);
     abt.mint(from, to, tokenId, tokenURI);
+
     assertEq(abt.ownerOf(tokenId), to);
     assertEq(abt.tokenURI(tokenId), tokenURI);
 
@@ -211,9 +245,14 @@ contract ERC4973Test is Test {
     address from = address(0);
     string memory tokenURI = "https://example.com/metadata.json";
     uint256 tokenId = 0;
+
+    vm.expectEmit(true, true, true, false);
+    emit Transfer(from, msg.sender, tokenId);
     abt.mint(from, msg.sender, tokenId, tokenURI);
+
     assertEq(abt.tokenURI(tokenId), tokenURI);
     assertEq(abt.ownerOf(tokenId), msg.sender);
+
     abt.mint(from, msg.sender, tokenId, tokenURI);
   }
 

--- a/src/ERC4973.t.sol
+++ b/src/ERC4973.t.sol
@@ -65,11 +65,12 @@ contract AccountBoundToken is ERC4973 {
   }
 
   function mint(
+    address from,
     address to,
     uint256 tokenId,
     string calldata uri
   ) external returns (uint256) {
-    return super._mint(to, tokenId, uri);
+    return _mint(from, to, tokenId, uri);
   }
 }
 
@@ -125,47 +126,52 @@ contract ERC4973Test is Test {
   }
 
   function testBalanceIncreaseAfterMint() public {
+    address from = address(0);
     address to = msg.sender;
     assertEq(abt.balanceOf(to), 0);
     string memory tokenURI = "https://example.com/metadata.json";
     uint256 tokenId = 0;
-    abt.mint(to, tokenId, tokenURI);
+    abt.mint(from, to, tokenId, tokenURI);
     assertEq(abt.balanceOf(to), 1);
   }
 
   function testBalanceIncreaseAfterMintAndUnequip() public {
+    address from = address(0);
     address to = address(this);
     assertEq(abt.balanceOf(to), 0);
     string memory tokenURI = "https://example.com/metadata.json";
     uint256 tokenId = 0;
-    abt.mint(to, tokenId, tokenURI);
+    abt.mint(from, to, tokenId, tokenURI);
     assertEq(abt.balanceOf(to), 1);
     abt.unequip(tokenId);
     assertEq(abt.balanceOf(to), 0);
   }
 
   function testMint() public {
+    address from = address(0);
     string memory tokenURI = "https://example.com/metadata.json";
     uint256 tokenId = 0;
-    abt.mint(msg.sender, tokenId, tokenURI);
+    abt.mint(from, msg.sender, tokenId, tokenURI);
     assertEq(abt.tokenURI(tokenId), tokenURI);
     assertEq(abt.ownerOf(tokenId), msg.sender);
   }
 
   function testMintToExternalAddress() public {
+    address from = address(0);
     address thirdparty = address(1337);
     string memory tokenURI = "https://example.com/metadata.json";
     uint256 tokenId = 0;
-    abt.mint(thirdparty, tokenId, tokenURI);
+    abt.mint(from, thirdparty, tokenId, tokenURI);
     assertEq(abt.tokenURI(tokenId), tokenURI);
     assertEq(abt.ownerOf(tokenId), thirdparty);
   }
 
   function testMintAndUnequip() public {
     string memory tokenURI = "https://example.com/metadata.json";
+    address from = address(0);
     address to = address(this);
     uint256 tokenId = 0;
-    abt.mint(to, tokenId, tokenURI);
+    abt.mint(from, to, tokenId, tokenURI);
     assertEq(abt.ownerOf(tokenId), to);
     assertEq(abt.tokenURI(tokenId), tokenURI);
     abt.unequip(tokenId);
@@ -173,9 +179,10 @@ contract ERC4973Test is Test {
 
   function testUnequippingAsNonAuthorizedAccount() public {
     string memory tokenURI = "https://example.com/metadata.json";
+    address from = address(0);
     address to = address(this);
     uint256 tokenId = 0;
-    abt.mint(to, tokenId, tokenURI);
+    abt.mint(from, to, tokenId, tokenURI);
     assertEq(abt.ownerOf(tokenId), to);
     assertEq(abt.tokenURI(tokenId), tokenURI);
 
@@ -188,8 +195,9 @@ contract ERC4973Test is Test {
   function testUnequippingNonExistentTokenId() public {
     string memory tokenURI = "https://example.com/metadata.json";
     address to = address(this);
+    address from = address(0);
 		uint256 tokenId = 0;
-    abt.mint(to, tokenId, tokenURI);
+    abt.mint(from, to, tokenId, tokenURI);
     assertEq(abt.ownerOf(tokenId), to);
     assertEq(abt.tokenURI(tokenId), tokenURI);
 
@@ -200,12 +208,13 @@ contract ERC4973Test is Test {
   }
 
   function testFailToMintTokenToPreexistingTokenId() public {
+    address from = address(0);
     string memory tokenURI = "https://example.com/metadata.json";
     uint256 tokenId = 0;
-    abt.mint(msg.sender, tokenId, tokenURI);
+    abt.mint(from, msg.sender, tokenId, tokenURI);
     assertEq(abt.tokenURI(tokenId), tokenURI);
     assertEq(abt.ownerOf(tokenId), msg.sender);
-    abt.mint(msg.sender, tokenId, tokenURI);
+    abt.mint(from, msg.sender, tokenId, tokenURI);
   }
 
   function testFailRequestingNonExistentTokenURI() public view {

--- a/src/ERC4973.t.sol
+++ b/src/ERC4973.t.sol
@@ -218,12 +218,11 @@ contract ERC4973Test is Test {
 
   function testGiveWithRejectingERC1271Contract() public {
     string memory tokenURI = "https://contenthash.com";
-    address from = address(this);
     address to = address(rejecter);
     bytes memory signature;
 
     vm.expectRevert(bytes("_safeCheckAgreement: invalid signature"));
-    uint256 tokenId = abt.give(
+    abt.give(
       to,
       tokenURI,
       signature
@@ -232,13 +231,12 @@ contract ERC4973Test is Test {
 
   function testTakeWithRejectingERC1271Contract() public {
     string memory tokenURI = "https://contenthash.com";
-    address to = address(this);
 
     address from = address(rejecter);
     bytes memory signature;
 
     vm.expectRevert(bytes("_safeCheckAgreement: invalid signature"));
-    uint256 tokenId = abt.take(
+    abt.take(
       from,
       tokenURI,
       signature
@@ -247,7 +245,6 @@ contract ERC4973Test is Test {
 
   function testGiveWithApprovingERC1271Contract() public {
     string memory tokenURI = "https://contenthash.com";
-    address from = address(this);
     address to = address(approver);
     bytes memory signature;
 
@@ -372,7 +369,6 @@ contract ERC4973Test is Test {
 
   function testGiveAndUnequipAndRegive() public {
     string memory tokenURI = "https://contenthash.com";
-    address from = address(this);
     address to = address(aa);
     bytes memory signature;
 
@@ -490,7 +486,6 @@ contract ERC4973Test is Test {
   function testPreventGivingToSelf() public {
     string memory tokenURI = "https://contenthash.com";
     address to = address(aa);
-    address from = address(aa);
     bytes memory signature;
 
     vm.expectRevert(bytes("give: cannot give from self"));
@@ -504,7 +499,6 @@ contract ERC4973Test is Test {
 
   function testPreventTakingToSelf() public {
     string memory tokenURI = "https://contenthash.com";
-    address to = address(aa);
     address from = address(aa);
     bytes memory signature;
 


### PR DESCRIPTION
Fixes https://github.com/rugpullindex/ERC4973/issues/39

* Removed unused variables
* Added `from` parameter in `Transfer` event
* Updating tests to check for the emit with the right topics